### PR TITLE
Fixes HMR for ES modules

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -26,7 +26,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var cache = {};
 
 exports.default = function (_ref) {
-  var module = _ref.module,
+  var ctx = _ref.ctx,
+      module = _ref.module,
       hotId = _ref.hotId;
 
   // Make the API aware of the Vue that you are using.
@@ -47,7 +48,7 @@ exports.default = function (_ref) {
   if (!module.exports) {
     // babel did not transform modules
     // eslint-disable-next-line no-underscore-dangle
-    component = module.__esModule ? module.default : module;
+    component = ctx.__esModule ? ctx.default : ctx;
   } else {
     // eslint-disable-next-line no-underscore-dangle
     component = module.exports.__esModule ? module.exports.default : module.exports;

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ exports.default = function (output) {
   var fileName = _path2.default.basename(this.resourcePath);
   var hotId = JSON.stringify(moduleId + '/' + fileName);
 
-  return output + ' if (module.hot) require(' + api + ')({ module: module, hotId: ' + hotId + ' });';
+  return output + ' if (module.hot) require(' + api + ')({ ctx: this, module: module, hotId: ' + hotId + ' });';
 };
 
 var _path = require('path');

--- a/src/api.js
+++ b/src/api.js
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
 // a reload or just a rerender is needed.
 const cache = {};
 
-export default ({ module, hotId }) => {
+export default ({ ctx, module, hotId }) => {
   // Make the API aware of the Vue that you are using.
   // Also checks compatibility.
   api.install(Vue, false);
@@ -28,7 +28,7 @@ export default ({ module, hotId }) => {
   let component;
   if (!module.exports) { // babel did not transform modules
     // eslint-disable-next-line no-underscore-dangle
-    component = module.__esModule ? module.default : module;
+    component = ctx.__esModule ? ctx.default : ctx;
   } else {
     // eslint-disable-next-line no-underscore-dangle
     component = module.exports.__esModule ? module.exports.default : module.exports;

--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,5 @@ export default function (output) {
   const fileName = path.basename(this.resourcePath);
   const hotId = JSON.stringify(`${moduleId}/${fileName}`);
 
-  return `${output} if (module.hot) require(${api})({ module: module, hotId: ${hotId} });`;
+  return `${output} if (module.hot) require(${api})({ ctx: this, module: module, hotId: ${hotId} });`;
 }

--- a/tests/webpack/src/component.jsx
+++ b/tests/webpack/src/component.jsx
@@ -23,7 +23,7 @@ export default {
   // eslint-disable-next-line no-unused-vars
   render(h) {
     return <div>
-      <span>Hello, {this.name}!!</span>
+      <span>(cjs) Hello, {this.name}!!</span>
       <button onClick={this.toggleName}>Toggle!!</button>
       <NativeModule />
     </div>;

--- a/tests/webpack/src/nativeModules/component.jsx
+++ b/tests/webpack/src/nativeModules/component.jsx
@@ -1,28 +1,19 @@
 export default {
-  name: 'MyJsxComponent',
+  name: 'MyNativeEsModuleJsxComponent',
   data() {
     return {
-      name: 'world',
+      greeting: 'Hello',
     };
-  },
-  computed: {
-    test() {
-      return this.name.split('l');
-    },
-    test2() {
-      return this.name.split('l');
-    },
   },
   methods: {
     toggleName() {
-      this.name = this.name === 'world' ? 'alls' : 'world';
+      this.greeting = this.greeting === 'Hello' ? 'Salut' : 'Hello';
     },
   },
   // eslint-disable-next-line no-unused-vars
   render(h) {
     return <div>
-      <br /><strong>Native module, untransformed by babel</strong><br />
-      <span>Hello, {this.name}!!</span>
+      <span>(esm) {this.greeting}, world!!</span>
       <button onClick={this.toggleName}>Toggle!!</button>
     </div>;
   },


### PR DESCRIPTION
Pass in `this` as `ctx` to the API, which reference the updated native ES module. There seems to be a reference to the module in `module.__proto__.exports.a` but (1) it seems weird to use that, and (2) it doesn't work with it as it doesn't have the `beforeCreate` and al. hooks from `vue-hot-reload-api`. Not sure `ctx` is the best name for that variable but.. that's what I got.

ref: #7 