### PR TITLE
Point to the right property for imported modules

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -48,7 +48,7 @@ exports.default = function (_ref) {
   if (!module.exports) {
     // babel did not transform modules
     // eslint-disable-next-line no-underscore-dangle
-    component = ctx.__esModule ? ctx.default : ctx;
+    component = ctx.__esModule ? ctx.default : ctx.a;
   } else {
     // eslint-disable-next-line no-underscore-dangle
     component = module.exports.__esModule ? module.exports.default : module.exports;

--- a/src/api.js
+++ b/src/api.js
@@ -28,7 +28,7 @@ export default ({ ctx, module, hotId }) => {
   let component;
   if (!module.exports) { // babel did not transform modules
     // eslint-disable-next-line no-underscore-dangle
-    component = ctx.__esModule ? ctx.default : ctx;
+    component = ctx.__esModule ? ctx.default : ctx.a;
   } else {
     // eslint-disable-next-line no-underscore-dangle
     component = module.exports.__esModule ? module.exports.default : module.exports;

--- a/tests/webpack/src/nativeModules/button.jsx
+++ b/tests/webpack/src/nativeModules/button.jsx
@@ -1,0 +1,10 @@
+export default {
+  name: 'Button',
+  render() {
+    return (
+      <button onClick={(e) => this.$emit('click', e)}>
+        {this.$slots.default}
+      </button>
+    )
+  }
+}

--- a/tests/webpack/src/nativeModules/component.jsx
+++ b/tests/webpack/src/nativeModules/component.jsx
@@ -1,3 +1,5 @@
+import Button from './Button.jsx'
+
 export default {
   name: 'MyNativeJsxComponent',
   data() {
@@ -10,11 +12,10 @@ export default {
       this.greeting = this.greeting === 'Hello' ? 'Salut' : 'Hello';
     },
   },
-  // eslint-disable-next-line no-unused-vars
-  render(h) {
+  render() {
     return <div>
       <span>(esm) {this.greeting}, world!!</span>
-      <button onClick={this.toggleName}>Toggle!!</button>
+      <Button onClick={this.toggleName}>Toggle!</Button>
     </div>;
   },
 };


### PR DESCRIPTION
First, sorry about all the PRs, I'm not super familiar with how Webpack's bundles everything together.

After some more testing, I've realized that only the first imported file is marked with `__esModule`, for the others, the component lives on the `a` property.. as you can see below.

![screen shot 2017-05-30 at 14 31 23](https://cloud.githubusercontent.com/assets/610207/26599025/1e9ca5b8-4545-11e7-9b0e-bfc4e7235216.png)