### PR TITLE
Support webpack5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ module.exports = function vueJsxHotLoader(output, sourceMap) {
 
     this.callback(
         null,
-        `${output}\n// VUE JSX HOT LOADER //\nif (module.hot) require(${api})({ Vue: require('vue'), ctx: eval('this'), module: module, hotId: ${hotId} });`,
+        `${output}\n// VUE JSX HOT LOADER //\nif (module.hot) require(${api})({ Vue: require('vue'), ctx: __webpack_exports__, module: module, hotId: ${hotId} });`,
         sourceMap,
     );
 };


### PR DESCRIPTION
`eval('this')` in Webpack5 is window
use `__webpack_exports__` to replace it
it can work in Webpack4